### PR TITLE
Add .ocp files for ocp-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ setup.log
 setup.data
 _build
 *~
+/_obuild
+/src/syntax/r_lang_parser_y.mly

--- a/README
+++ b/README
@@ -98,6 +98,8 @@
    Currently, it works on Debian, and someone has reported me
    that it compiles without problems on Mac OS X 10 6.3.
 
+   If you use ocp-build, you should edit the top 'build.ocp' file,
+   and then call `ocp-build init && ocp-build`.
 
 -6-  How to use the library
 ===========================

--- a/build.ocp
+++ b/build.ocp
@@ -1,0 +1,21 @@
+(* THIS FILE SHOULD BE GENERATED. For now, modify it to fit your R config *)
+
+(* pkg-config --cflags libR  *)
+R_include = "-I/usr/local/lib/R/include";
+
+(* pkg-config --libs libR *)
+R_libs = "-L/usr/local/lib -L/usr/local/lib/R/lib -Wl,--export-dynamic -fopenmp -lR ";
+
+(* pkg-config --libs libRmath  *)
+Rmath_libs = "-L/usr/local/lib -lRmath -lm"
+
+R_ccopt = [ R_include ]
+R_cclib = [ R_libs Rmath_libs ]
+R_pp = [
+      "camlp4" "-I" "%{camlp4_FULL_SRC_DIR}%"
+        "-parser" "o" "-parser" "op" "-printer" "p"
+        "-parser" "Camlp4GrammarParser" "-parser" "Camlp4QuotationCommon"
+        "-parser" "Camlp4OCamlRevisedQuotationExpander"
+        "%{R_syntax_FULL_DST_DIR}%/R_syntax.cma"
+    ]
+R_pp_deps = [  "%{R_syntax_FULL_DST_DIR}%/R_syntax.cma" ]

--- a/examples/build.ocp
+++ b/examples/build.ocp
@@ -1,0 +1,4 @@
+begin program "R_test_suite"
+    files = [ "test_suite.ml" ]
+    requires = [ "R_interpreter" ]
+end

--- a/src/base/build.ocp
+++ b/src/base/build.ocp
@@ -1,0 +1,7 @@
+
+begin library "R_base"
+    pp = R_pp
+    pp_deps = R_pp_deps
+    files = [ "r_base_types.ml" "r_base_stubs.ml" "r_base.ml" ]
+    requires = [ "R_intepreter" "R_syntax" ]
+end

--- a/src/build.ocp
+++ b/src/build.ocp
@@ -1,0 +1,47 @@
+
+
+begin library "R"
+    
+    ccopt = R_ccopt
+    cclib = R_cclib
+    
+    requires = [ "unix" ]
+    
+  files = [
+    "initialisation_stub.c";
+    "databridge.c"
+    "sexp.c"
+    "allocation_stub.c"
+    "read_internal_stub.c"
+      "write_internal_stub.c"
+      "symbols_stub.c"
+      "conversion_stub.c"
+      "s3_stub.c"
+      "s4_stub.c"
+      "r_parser_stub.c"
+      "reduction_stub.c"
+      
+      "data.ml" "allocation.ml" "read_internal.ml" "sexprec.ml"
+      "sexptype.ml" "write_internal.ml" "conversion.ml" "environment.ml"
+      "r_parser.ml" "reduction.ml" "standard.ml" "initialisation.ml"
+      "internal.ml" "promise.ml" "symbols.ml" "s3.ml" "s4.ml" "r.ml"
+  ]
+
+    build_rules = [
+      "standard.ml" (
+        sources = [ "standard.R" ];
+        commands = [
+          { "R" "--silent" "--vanilla" "--slave" }(stdin = "standard.R" stdout = "standard.ml") 
+        ]
+      )
+    ]
+    
+    end
+
+begin objects "R_interpreter"
+
+    requires = [ "R" ]
+    files = [ "R_interpreter.ml" ]
+
+end
+

--- a/src/grDevices/build.ocp
+++ b/src/grDevices/build.ocp
@@ -1,0 +1,6 @@
+
+
+begin library "R_grDevices"
+    files = [ "R_grDevices.ml" ]
+    requires = [ "R" "R_base" ]
+end

--- a/src/graphics/build.ocp
+++ b/src/graphics/build.ocp
@@ -1,0 +1,6 @@
+
+
+begin library "R_graphics"
+    files = [ "r_graphics.ml" "r_graphics_stubs.ml" ]
+    requires = [ "R_interpreter" "R_base" ]
+end

--- a/src/math/build.ocp
+++ b/src/math/build.ocp
@@ -1,0 +1,4 @@
+begin library "R_math"
+    cclib = R_cclib;
+    files = [ "r_math_stubs.c"; "r_math.ml" ]
+end

--- a/src/methods/build.ocp
+++ b/src/methods/build.ocp
@@ -1,0 +1,7 @@
+
+
+begin library "R_methods"
+    files = [ "r_methods.ml" ]
+    requires = [ "R" ]
+    
+end

--- a/src/stats/build.ocp
+++ b/src/stats/build.ocp
@@ -1,0 +1,6 @@
+
+
+begin library "R_stats"
+    files = [ "r_stats_stubs.ml" "r_stats.ml" ]
+    requires = [ "R" "R_interpreter" "R_base" ]
+end

--- a/src/syntax/build.ocp
+++ b/src/syntax/build.ocp
@@ -1,0 +1,26 @@
+
+
+begin library "R_syntax"
+    pp = [ "camlp4" "-I" "%{camlp4_FULL_SRC_DIR}%"
+             "-parser" "o" "-parser" "op" "-printer" "p"
+             "-parser" "Camlp4GrammarParser" "-parser" "Camlp4QuotationCommon"
+             "-parser" "Camlp4OCamlRevisedQuotationExpander" "-ignore" "foo"
+         ]
+
+    requires = [ "camlp4lib" ]
+    files = [
+      "pa_r.ml" "r_lang_ast.ml"
+        "r_lang_parser_y.mly" (ocamlyacc = "menhir")
+
+        "r_lang_lexer.mll" "pa_rscript.ml" "r_lang_parser.ml"
+
+    ]
+    build_rules = [
+      "r_lang_parser_y.mly" (
+        sources = "r_lang_parser_y_aux.mly"
+          commands = [
+            { "cp" "-f" "r_lang_parser_y_aux.mly" "r_lang_parser_y.mly" }
+          ]
+      )
+    ]
+end


### PR DESCRIPTION
You need to edit build.ocp to create your R config. There is also
currently no install rules for files generated with ocp-build, except
`ocp-build install` that will install files as R_XXX packages instead of
R.XXX for ocamlfind.