### PR TITLE
Fix pkg-config and clean up Configurator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ uninstall:
 utop:
 	dune utop lib
 
+test:
+	dune runtest
+
 clean:
 	dune clean
 

--- a/lib/config/discover.ml
+++ b/lib/config/discover.ml
@@ -1,25 +1,26 @@
 module C = Configurator.V1
 module S = String
 
+let trim_to_list str =
+  S.split_on_char ' ' (S.trim str)
+
 let cfig c =
   let default: C.Pkg_config.package_conf = {
       libs = ["-lR"; "-lRmath"];
       cflags = [] }
   in
-  let rlib = C.Process.run c "pkg-config" ["--libs-only-L"; "--libs-only-l"; "libR"] in
-  let rmlib = C.Process.run c "pkg-config" ["--libs-only-L"; "--libs-only-l"; "libRmath"] in
-  let rflg = C.Process.run c "pkg-config" ["--cflags"; "libR"] in
-  let rmflg = C.Process.run c "pkg-config" ["--cflags"; "libRmath"] in
-  let chk = (rlib.exit_code, rmlib.exit_code, rflg.exit_code, rmflg.exit_code) in
-  let lib = (S.split_on_char ' ' (S.trim rlib.stdout)) @ (S.split_on_char ' ' (S.trim rmlib.stdout)) in
-  let flg = (S.split_on_char ' ' (S.trim rflg.stdout)) @ (S.split_on_char ' ' (S.trim rmflg.stdout)) in  
+  let rlib = C.Process.run c "pkg-config" ["--libs-only-L"; "--libs-only-l"; "libR"; "libRmath"] in
+  let rflg = C.Process.run c "pkg-config" ["--cflags"; "libR"; "libRmath"] in
+  let chk = (rlib.exit_code, rflg.exit_code) in
+  let lib = trim_to_list rlib.stdout in
+  let flg = trim_to_list rflg.stdout in  
   let discover: C.Pkg_config.package_conf = {
       libs = lib;
       cflags = flg }
   in
   let conf =
     match chk with
-    | (0, 0, 0, 0) -> discover
+    | (0, 0) -> discover
     | _ -> default
   in
   C.Flags.write_sexp "c_flags.sexp" conf.cflags;

--- a/lib/config/discover.ml
+++ b/lib/config/discover.ml
@@ -1,15 +1,27 @@
 module C = Configurator.V1
+module S = String
 
-let cfig  c =
-  let default = { C.Pkg_config.libs = ["-lR"]; cflags = [] } in
+let cfig c =
+  let default: C.Pkg_config.package_conf = {
+      libs = ["-lR"; "-lRmath"];
+      cflags = [] }
+  in
+  let rlib = C.Process.run c "pkg-config" ["--libs-only-L"; "--libs-only-l"; "libR"] in
+  let rmlib = C.Process.run c "pkg-config" ["--libs-only-L"; "--libs-only-l"; "libRmath"] in
+  let rflg = C.Process.run c "pkg-config" ["--cflags"; "libR"] in
+  let rmflg = C.Process.run c "pkg-config" ["--cflags"; "libRmath"] in
+  let chk = (rlib.exit_code, rmlib.exit_code, rflg.exit_code, rmflg.exit_code) in
+  let lib = (S.split_on_char ' ' (S.trim rlib.stdout)) @ (S.split_on_char ' ' (S.trim rmlib.stdout)) in
+  let flg = (S.split_on_char ' ' (S.trim rflg.stdout)) @ (S.split_on_char ' ' (S.trim rmflg.stdout)) in  
+  let discover: C.Pkg_config.package_conf = {
+      libs = lib;
+      cflags = flg }
+  in
   let conf =
-    match C.Pkg_config.get c with
-    | None -> default
-    | Some pc ->
-       match C.Pkg_config.query pc ~package:"libR libRmath" with
-       | None -> default
-       | Some deps -> deps in
-
+    match chk with
+    | (0, 0, 0, 0) -> discover
+    | _ -> default
+  in
   C.Flags.write_sexp "c_flags.sexp" conf.cflags;
   C.Flags.write_sexp "c_library_flags.sexp" conf.libs;;
 

--- a/lib/config/discover.ml
+++ b/lib/config/discover.ml
@@ -1,21 +1,16 @@
-open Base
-open Stdio
 module C = Configurator.V1
 
-let write_sexp fn sexp =
-  Out_channel.write_all fn ~data:(Sexp.to_string sexp)
+let cfig  c =
+  let default = { C.Pkg_config.libs = ["-lR"]; cflags = [] } in
+  let conf =
+    match C.Pkg_config.get c with
+    | None -> default
+    | Some pc ->
+       match C.Pkg_config.query pc ~package:"libR libRmath" with
+       | None -> default
+       | Some deps -> deps in
 
-let () =
-  C.main ~name:"OCaml_R" (fun c ->
-      let default : C.Pkg_config.package_conf =
-        { libs   = ["-lR"] ; cflags = [] }
-      in
-      let conf =
-        match C.Pkg_config.get c with
-        | None -> default
-        | Some pc ->
-          Option.value (C.Pkg_config.query pc ~package:"libR libRmath") ~default
-      in
-      write_sexp "c_flags.sexp"         (sexp_of_string (String.concat ~sep:" " conf.cflags)) ;
-      write_sexp "c_library_flags.sexp" (sexp_of_string (String.concat ~sep:" " conf.libs))
-    )
+  C.Flags.write_sexp "c_flags.sexp" conf.cflags;
+  C.Flags.write_sexp "c_library_flags.sexp" conf.libs;;
+
+C.main ~name:"OCaml-R" cfig;;

--- a/lib/config/dune
+++ b/lib/config/dune
@@ -1,3 +1,3 @@
 (executable
  (name discover)
- (libraries base stdio dune.configurator))
+ (libraries dune.configurator))


### PR DESCRIPTION
Configurator wasn't correctly adding the output of pkg-config (R instance in non-standard location).  It was adding quotes to the includes and so was giving errors that `R.h` and `Rmath.h` couldn't be found.  This pull request now compiles correctly and passes `dune runtest`.