### PR TITLE
Fix configurator output for empty cflags list

### DIFF
--- a/lib/config/discover.ml
+++ b/lib/config/discover.ml
@@ -2,7 +2,9 @@ module C = Configurator.V1
 module S = String
 
 let trim_to_list str =
-  S.split_on_char ' ' (S.trim str)
+  match S.trim str with
+  | "" -> []
+  | str -> S.split_on_char ' ' str
 
 let cfig c =
   let default: C.Pkg_config.package_conf = {


### PR DESCRIPTION
I was having some trouble [upgrading](https://github.com/bcc32/nixpkgs/commit/560620987b0d6ee908501af4ab4808856514f216) the version of ocaml-r in nixpkgs to 0.4.0, and noticed that gcc was being passed a spurious empty string argument.  I believe the recent change to this file may have resulted in empty flag sets being output to the sexp file as a single quoted empty string instead of an empty list as intended.