### PR TITLE
Remove ocamlr_inspect_symsxp_internal

### DIFF
--- a/lib/read_internal_stub.c
+++ b/lib/read_internal_stub.c
@@ -91,16 +91,6 @@ CAMLprim value ocamlr_inspect_symsxp_pname (value sexp) {
 }
 
 
-/**  Returns the internal sexp of a symbol.
-  *
-  *  @param sexp An R value of sexptype SYMSXP.
-  *  @return The internal value of a symbol.
-  */
-CAMLprim value ocamlr_inspect_symsxp_internal (value sexp) {
-  return(Val_sexp(INTERNAL(Sexp_val(sexp))));
-}
-
-
 /**  Returns the head element of a pairlist.
   *
   *  @param sexp An R pairlist.


### PR DESCRIPTION
Looks like this change has been overlooked in a62a750cbc26d738a3eb404b03a042008329587e which removed the OCaml interface to this function.