### PR TITLE
Enable access to deprecated functions

### DIFF
--- a/lib/s3_stub.c
+++ b/lib/s3_stub.c
@@ -32,6 +32,7 @@
 #include <caml/callback.h>
 #include <caml/signals.h>
 #include <caml/custom.h>
+#define ENABLE_LEGACY_NONAPI_FUNS
 #include <R.h>
 #include <Rdefines.h>
 #include <Rinternals.h>


### PR DESCRIPTION
The ATTRIB function has been deprecated in R 4.6

Note that removing `get_attributes` might be a sensible fix too.